### PR TITLE
API bump/version?

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,8 +1,8 @@
 name: SimplePortals
 main: falkirks\simpleportals\SimplePortals
 author: Falkirks
-version: 0.0.5
-api: [1.10.0,2.0.0]
+version: 0.0.6
+api: [1.10.0,2.0.0,3.0.0-ALPHA5]
 depend: ["SimpleWarp"]
 permissions:
   simpleportals:


### PR DESCRIPTION
I've used this plugin on ALPHA3, 4, and 5 for quite some time and it's stable.  Don't know if you wanted the version bumped or not, and you are welcome to ignore this PR and do your own, I just thought it would help keep poggit updated as this really makes warps easy for the kiddos to use.