### PR TITLE
Dependency issue due to pmmp moving protocol folder to subfolder

### DIFF
--- a/src/falkirks/simpleportals/CreationListener.php
+++ b/src/falkirks/simpleportals/CreationListener.php
@@ -13,7 +13,7 @@ use pocketmine\event\player\PlayerChatEvent;
 use pocketmine\event\player\PlayerInteractEvent;
 use pocketmine\item\FlintSteel;
 use pocketmine\math\Vector3;
-use pocketmine\network\protocol\UpdateBlockPacket;
+use pocketmine\network\mcpe\protocol\UpdateBlockPacket;
 
 class CreationListener implements Listener{
     /** @var  SimplePortals */


### PR DESCRIPTION
Since pocketmine\network\protocol\UpdateBlockPacket moved to pocketmine\network\mcpe\protocol\UpdateBlockPacket this plugin gives a unknown circular dependency error on load when compiled to phar (does not do it running from source).  Anyway, changing this line to the correct path seems to have fixed.